### PR TITLE
Added test step to verify offduty has no side effects

### DIFF
--- a/qualifier/tests.py
+++ b/qualifier/tests.py
@@ -123,6 +123,9 @@ class RegistrationTests(QualifierTestCase):
                 request.send.reset_mock()
 
                 await self.manager(create_request({"type": "staff.offduty", "id": id_}, request.receive, request.send))
+                
+                request.receive.assert_not_called()
+                request.send.assert_not_called()
 
         self.verify_staff_dict()
         self.assertEqual(self.manager.staff, {}, msg="Not all staff removed after going off-duty")

--- a/qualifier/tests.py
+++ b/qualifier/tests.py
@@ -89,6 +89,9 @@ class RegistrationTests(QualifierTestCase):
 
         await self.manager(create_request({"type": "staff.offduty", "id": id_}, receive, send))
 
+        receive.assert_not_called()
+        send.assert_not_called()
+
         self.verify_staff_dict()
 
         self.assertEqual(self.manager.staff, {}, msg="Staff not removed after going off-duty")


### PR DESCRIPTION
Originally there was no test for side effects during the `staff.offduty` check, which allows code that calls the ordering steps during the `staff.offduty` call to pass the test. These new assertions will ensure no order coroutines are called during the `staff.offduty` step.