### PR TITLE
Use American spelling for "specialty"

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ An example `"staff.onduty"` request:
 {
 	"type": "staff.onduty",
 	"id": "AbCd3Fg",
-	"speciality": ["meat"]
+	"specialty": ["meat"]
 }
 ```
 
 When a `"staff.onduty"` request is received, you should add their request to the `self.staff` dictionary using their ID as the key. This is so that we can keep track of who is currently working.
 
-There is also a "speciality" key included, but you do not need to worry about that yet.
+There is also a "specialty" key included, but you do not need to worry about that yet.
 
 ### Step 2 - Off Duty
 At the end of the day, staff members will let your application know that they are going off-duty. This will be done with a new Request. You can identify an off-duty request by the Request scope key `"type"` — it will be set to `"staff.offduty"`. 
@@ -90,7 +90,7 @@ Requests from customers can be identified by the Request's scope dictionary's `"
 ```json
 {
 	"type": "order",
-	"speciality": "meat"
+	"specialty": "meat"
 }
 ```
 
@@ -110,28 +110,28 @@ await request.send(result)
 ```
 
 ### Step 4 - Order Specialization
-Certain staff are better at certain orders, making them faster at that type of order. You can read this from the staff's request `scope` dictionary with the `"speciality"` key.
+Certain staff are better at certain orders, making them faster at that type of order. You can read this from the staff's request `scope` dictionary with the `"specialty"` key.
 
 Example requests:
 ```json
 {
 	"type": "staff.onduty",
 	"id": "AbCd3Fg",
-        "speciality": ["pasta", "vegetables"]
+        "specialty": ["pasta", "vegetables"]
 }
 ```
 
 ```json
 {
 	"type": "order",
-	"speciality": "pasta"
+	"specialty": "pasta"
 }
 ```
 
-An order requires a certain specialty, which can be read via the order's `"speciality"` key in its `scope` dictionary. Your application should pass the order to a staff member that has the order's specialty.
+An order requires a certain specialty, which can be read via the order's `"specialty"` key in its `scope` dictionary. Your application should pass the order to a staff member that has the order's specialty.
 
 > **Note**
-> The `"speciality"` key is included in all `"staff.onduty"` requests, but absent from `"staff.offduty"` requests.
+> The `"specialty"` key is included in all `"staff.onduty"` requests, but absent from `"staff.offduty"` requests.
 
 #### Challenge Yourself
 We won't test you on how you distribute work between prioritized staff members, but in a self-respecting kitchen, work should be distributed fairly.

--- a/qualifier/tests.py
+++ b/qualifier/tests.py
@@ -13,7 +13,7 @@ STAFF_IDS = (
     "jmMZkSGVBbCDgKKMMSNPS", "HeLlOWoRlD123", "iKnowThatYouAreReadingThis",
     "PyTHonDIscorDCoDEJam", "iWAShereWRITINGthis"
 )
-SPECIALITIES = (
+SPECIALTIES = (
     "pasta", "meat", "vegetables", "non-food", "dessert",
 )
 
@@ -67,7 +67,7 @@ class RegistrationTests(QualifierTestCase):
         id_ = STAFF_IDS[0]
         receive, send = AsyncMock(), AsyncMock()
 
-        staff = create_request({"type": "staff.onduty", "id": id_, "speciality": [SPECIALITIES[0]]}, receive, send)
+        staff = create_request({"type": "staff.onduty", "id": id_, "specialty": [SPECIALTIES[0]]}, receive, send)
 
         await self.manager(staff)
 
@@ -96,10 +96,10 @@ class RegistrationTests(QualifierTestCase):
     async def test_multiple_staff_registration(self) -> None:
         staff: list[Request] = []
 
-        for id_, speciality in zip(STAFF_IDS, SPECIALITIES):
+        for id_, specialty in zip(STAFF_IDS, SPECIALTIES):
             receive, send = AsyncMock(), AsyncMock()
 
-            request = create_request({"type": "staff.onduty", "id": id_, "speciality": [speciality]}, receive, send)
+            request = create_request({"type": "staff.onduty", "id": id_, "specialty": [specialty]}, receive, send)
             staff.append(request)
 
             await self.manager(request)
@@ -135,14 +135,14 @@ class DeliveringTests(QualifierTestCase):
 
         complete_order, result = object(), object()
         staff = create_request(
-            {"type": "staff.onduty", "id": id_, "speciality": [SPECIALITIES[-1]]},
+            {"type": "staff.onduty", "id": id_, "specialty": [SPECIALTIES[-1]]},
             AsyncMock(return_value=result), AsyncMock()
         )
 
         await self.manager(staff)
 
         order = create_request(
-            {"type": "order", "speciality": SPECIALITIES[-1]},
+            {"type": "order", "specialty": SPECIALTIES[-1]},
             AsyncMock(return_value=complete_order), AsyncMock()
         )
         await self.manager(order)
@@ -168,21 +168,21 @@ class DeliveringTests(QualifierTestCase):
         staff_receive, staff_send = AsyncMock(), AsyncMock()
         staff = [
             create_request(
-                {"type": "staff.onduty", "id": id_, "speciality": [speciality]},
+                {"type": "staff.onduty", "id": id_, "specialty": [specialty]},
 
                 # We wrap the mocks so that they pass the ID of the staff, that way
                 # we can ensure that the order was both sent and received to the same staff.
                 wrap_receive_mock(id_, staff_receive), wrap_send_mock(id_, staff_send)
             )
-            for id_, speciality in zip(STAFF_IDS, reversed(SPECIALITIES))
+            for id_, specialty in zip(STAFF_IDS, reversed(SPECIALTIES))
         ]
 
         for request in staff:
             await self.manager(request)
 
         orders = [
-            create_request({"type": "order", "speciality": speciality}, AsyncMock(), AsyncMock())
-            for speciality in SPECIALITIES
+            create_request({"type": "order", "specialty": specialty}, AsyncMock(), AsyncMock())
+            for specialty in SPECIALTIES
         ]
 
         for order, (full_order, result) in zip(orders, sentinels):
@@ -214,27 +214,27 @@ class DeliveringTests(QualifierTestCase):
         for request in staff:
             await self.manager(create_request({"type": "staff.offduty", "id": request.scope["id"]}))
 
-    async def test_order_speciality_match(self) -> None:
-        staff_ids, specialities = list(STAFF_IDS), list(SPECIALITIES)
+    async def test_order_specialty_match(self) -> None:
+        staff_ids, specialties = list(STAFF_IDS), list(SPECIALTIES)
         random.shuffle(staff_ids)
-        random.shuffle(specialities)
+        random.shuffle(specialties)
 
         staff_receive, staff_send = AsyncMock(), AsyncMock()
         staff = {
             id_: create_request(
-                {"type": "staff.onduty", "id": id_, "speciality": [speciality]},
+                {"type": "staff.onduty", "id": id_, "specialty": [specialty]},
 
                 # We wrap the mocks so that they pass the ID of the staff, that way
                 # we can ensure that the order was both sent and received to the same staff.
                 wrap_receive_mock(id_, staff_receive), wrap_send_mock(id_, staff_send)
             )
-            for id_, speciality in zip(staff_ids, specialities)
+            for id_, specialty in zip(staff_ids, specialties)
         }
 
         for request in staff.values():
             await self.manager(request)
 
-        orders = [create_request({"type": "order", "speciality": speciality}) for speciality in specialities * 10]
+        orders = [create_request({"type": "order", "specialty": specialty}) for specialty in specialties * 10]
 
         for order in orders:
             await self.manager(order)
@@ -243,39 +243,39 @@ class DeliveringTests(QualifierTestCase):
             staff_id = staff_send.call_args.args[0]
 
             self.assertIn(
-                order.scope["speciality"], staff[staff_id].scope["speciality"],
-                msg="Order speciality not matched with speciality of staff"
+                order.scope["specialty"], staff[staff_id].scope["specialty"],
+                msg="Order specialty not matched with specialty of staff"
             )
             staff_send.reset_mock()
 
         for request in staff.values():
             await self.manager(create_request({"type": "staff.offduty", "id": request.scope["id"]}))
 
-    async def test_uneven_order_speciality(self) -> None:
-        # Similar to test_order_speciality_match() but there are multiple staff
-        # with the same speciality.
-        staff_ids, specialities = list(STAFF_IDS), list(SPECIALITIES[:2])
+    async def test_uneven_order_specialty(self) -> None:
+        # Similar to test_order_specialty_match() but there are multiple staff
+        # with the same specialty.
+        staff_ids, specialties = list(STAFF_IDS), list(SPECIALTIES[:2])
         random.shuffle(staff_ids)
-        random.shuffle(specialities)
+        random.shuffle(specialties)
 
         staff_receive, staff_send = AsyncMock(), AsyncMock()
         staff = {
             id_: create_request(
-                {"type": "staff.onduty", "id": id_, "speciality": [speciality]},
+                {"type": "staff.onduty", "id": id_, "specialty": [specialty]},
 
                 # We wrap the mocks so that they pass the ID of the staff, that way
                 # we can ensure that the order was both sent and received to the same staff.
                 wrap_receive_mock(id_, staff_receive), wrap_send_mock(id_, staff_send)
             )
-            for id_, speciality in zip(staff_ids, itertools.cycle(specialities))
+            for id_, specialty in zip(staff_ids, itertools.cycle(specialties))
         }
 
         for request in staff.values():
             await self.manager(request)
 
         orders = [
-            create_request({"type": "order", "speciality": speciality})
-            for speciality in itertools.chain(*itertools.repeat(specialities, 5))
+            create_request({"type": "order", "specialty": specialty})
+            for specialty in itertools.chain(*itertools.repeat(specialties, 5))
         ]
 
         for order in orders:
@@ -285,36 +285,36 @@ class DeliveringTests(QualifierTestCase):
             staff_id = staff_send.call_args.args[0]
 
             self.assertIn(
-                order.scope["speciality"], staff[staff_id].scope["speciality"],
-                msg="Order speciality not matched with speciality of staff"
+                order.scope["specialty"], staff[staff_id].scope["specialty"],
+                msg="Order specialty not matched with specialty of staff"
             )
             staff_send.reset_mock()
 
         for request in staff.values():
             await self.manager(create_request({"type": "staff.offduty", "id": request.scope["id"]}))
 
-    async def test_multiple_specialities(self) -> None:
+    async def test_multiple_specialties(self) -> None:
         id_one, id_two = random.sample(STAFF_IDS, 2)
 
         staff_receive, staff_send = AsyncMock(), AsyncMock()
 
         staff_one = create_request(
-            {"type": "staff.onduty", "id": id_one, "speciality": [SPECIALITIES[0]]},
+            {"type": "staff.onduty", "id": id_one, "specialty": [SPECIALTIES[0]]},
             wrap_receive_mock(id_one, staff_receive),
             wrap_send_mock(id_one, staff_send)
         )
         await self.manager(staff_one)
 
         staff_two = create_request(
-            {"type": "staff.onduty", "id": id_two, "speciality": SPECIALITIES[1:]},
+            {"type": "staff.onduty", "id": id_two, "specialty": SPECIALTIES[1:]},
             wrap_receive_mock(id_two, staff_receive),
             wrap_send_mock(id_two, staff_send)
         )
         await self.manager(staff_two)
 
         orders = [
-            create_request({"type": "order", "speciality": speciality})
-            for speciality in itertools.chain(*itertools.repeat(SPECIALITIES, 5))
+            create_request({"type": "order", "specialty": specialty})
+            for specialty in itertools.chain(*itertools.repeat(SPECIALTIES, 5))
         ]
 
         for order in orders:
@@ -322,9 +322,9 @@ class DeliveringTests(QualifierTestCase):
 
             staff_send.assert_awaited_once()
             staff_id = staff_send.call_args.args[0]
-            if order.scope["speciality"] == SPECIALITIES[0]:
-                self.assertEqual(staff_id, staff_one.scope["id"], msg="Order speciality not match with speciality of staff")
+            if order.scope["specialty"] == SPECIALTIES[0]:
+                self.assertEqual(staff_id, staff_one.scope["id"], msg="Order specialty not match with specialty of staff")
             else:
-                self.assertEqual(staff_id, staff_two.scope["id"], msg="Order speciality not match with speciality of staff")
+                self.assertEqual(staff_id, staff_two.scope["id"], msg="Order specialty not match with specialty of staff")
 
             staff_send.reset_mock()


### PR DESCRIPTION
A common complaint amongst those who have completed the qualifier has been the esoteric spelling of the word "specialty". This choice of spelling has truly been disruptive, and this PR seeks to help minimize this disruption.