### PR TITLE
Ambiguous spelling warning exception for "specialty"

### DIFF
--- a/qualifier/tests.py
+++ b/qualifier/tests.py
@@ -52,7 +52,7 @@ def create_request(
     if 'speciality' in scope:
         scope = DictWrapper(scope)
 
-    return Request(scope, receive, send)
+    return Request(MappingProxyType(scope), receive, send)
 
 
 def wrap_receive_mock(id_: str, mock: AsyncMock) -> Callable[[], Awaitable[object]]:

--- a/qualifier/tests.py
+++ b/qualifier/tests.py
@@ -27,7 +27,32 @@ def create_request(
         receive: Callable[[], Awaitable[object]] = _receive,
         send: Callable[[object], Awaitable[Any]] = _send
 ) -> Request:
-    return Request(MappingProxyType(scope), receive, send)
+    """
+    Create a request object with the given scope and receive/send functions.
+    Raises an error with help message if 'specialty' is accessed.
+    """
+    _err = RuntimeError(
+        "You may be using the wrong spelling for 'speciality'"
+        "; The correct key name is 'speciality', not 'specialty'."
+    )
+
+    # Dict wrapper
+    class DictWrapper(dict):
+        def __getitem__(self, key):
+            if key == "specialty":
+                raise _err
+            return super().__getitem__(key)
+
+        def get(self, key, default=None):
+            if key == "specialty":
+                raise _err
+            return super().get(key, default)
+
+    # Added specialty spelling warning if `speciality` is used
+    if 'speciality' in scope:
+        scope = DictWrapper(scope)
+
+    return Request(scope, receive, send)
 
 
 def wrap_receive_mock(id_: str, mock: AsyncMock) -> Callable[[], Awaitable[object]]:

--- a/qualifier/tests.py
+++ b/qualifier/tests.py
@@ -22,6 +22,24 @@ async def _receive() -> None: ...
 async def _send(_: object) -> None: ...
 
 
+class WarnTypoAccess(dict):
+    def __getitem__(self, key):
+        if key == "specialty":
+            raise RuntimeError(
+                "You may be using the wrong spelling for 'speciality'"
+                "; The correct key name is 'speciality', not 'specialty'."
+            )
+        return super().__getitem__(key)
+
+    def get(self, key, default=None):
+        if key == "specialty":
+            raise RuntimeError(
+                "You may be using the wrong spelling for 'speciality'"
+                "; The correct key name is 'speciality', not 'specialty'."
+            )
+        return super().get(key, default)
+
+
 def create_request(
         scope: dict[str, Any],
         receive: Callable[[], Awaitable[object]] = _receive,
@@ -31,28 +49,7 @@ def create_request(
     Create a request object with the given scope and receive/send functions.
     Raises an error with help message if 'specialty' is accessed.
     """
-    _err = RuntimeError(
-        "You may be using the wrong spelling for 'speciality'"
-        "; The correct key name is 'speciality', not 'specialty'."
-    )
-
-    # Dict wrapper
-    class DictWrapper(dict):
-        def __getitem__(self, key):
-            if key == "specialty":
-                raise _err
-            return super().__getitem__(key)
-
-        def get(self, key, default=None):
-            if key == "specialty":
-                raise _err
-            return super().get(key, default)
-
-    # Added specialty spelling warning if `speciality` is used
-    if 'speciality' in scope:
-        scope = DictWrapper(scope)
-
-    return Request(MappingProxyType(scope), receive, send)
+    return Request(MappingProxyType(WarnTypoAccess(scope)), receive, send)
 
 
 def wrap_receive_mock(id_: str, mock: AsyncMock) -> Callable[[], Awaitable[object]]:


### PR DESCRIPTION
Previously discussed in #4 for the prevalence of issues regarding the mis-spelling of "speciality" in some dialects.

To preserve backward compatibility with existing checks, this proposal adds a special `RuntimeError` message that is raised whenever access is attempted on the `MappingProxyType` for the key `specialty` when the correct key `speciality` exists. 

Additionally, to ensure `len()` checks still work as intended, this does not actually add any new keys to the dictionary, only overriding the `__getitem__` and `get` behavior.

This should not affect any existing tests or submissions.

Example:
```py
request.scope.get('specialty')
>> RuntimeError: You may be using the wrong spelling for 'speciality'; The correct key name is 'speciality', not 'specialty'.

request.scope['specialty']
>> RuntimeError: You may be using the wrong spelling for 'speciality'; The correct key name is 'speciality', not 'specialty'.
```